### PR TITLE
Update OfficialUrls.xml

### DIFF
--- a/OfficialUrls.xml
+++ b/OfficialUrls.xml
@@ -424,7 +424,7 @@
 	<regex>
 	<name>get-url</name>
 	<expres>"m3u8_url":"(.*?)"</expres>
-	<page>http://www.tvroyal.org.uk</page>
+	<page>http://www.tvroyal.com/</page>
 	<agent>Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1</agent>
 	</regex>
 	</item>


### PR DESCRIPTION
Royal TV Somalia new website at http://www.tvroyal.com/ hoping regex can get the link. Looking at source code the link is displayed but link doesn't play in vlc. Using developer tools on firefox, I grabbed http://cdn01.iqbroadcast.tv:8081/g1/6ryltv/playlist.m3u8?wmsAuthSign=c2VydmVyX3RpbWU9NS8yOC8yMDE2IDExOjQ2OjE4IFBNJmhhc2hfdmFsdWU9VjVQbnZOZGNnT1E3SU5YRldqNnpmQT09JnZhbGlkbWludXRlcz0yMA==
and it was able to play in vlc on first shot. Can someone please check?